### PR TITLE
Update MeshEx bounding sphere representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,23 +27,22 @@ The ssbh_lib library also supports the non SSBH formats [MeshEx](https://github.
 For making quick edits to SSBH files in a text editor, use [ssbh_lib_json](#ssbh_lib_json). [ssbh_data_json](#ssbh_data_json) supports fewer formats than ssbh_lib_json but adds the ability to decode and edit the buffer data in Mesh or Anim files. Python bindings for ssbh_data are available with [ssbh_data_py](https://github.com/ScanMountGoat/ssbh_data_py). 
 
 ## ssbh_lib_json
-A command line tool for creating and editing SSBH binary data using JSON. The MeshEx and Adj formats are also supported. Drag a properly formatted JSON file onto the executable to create a binary file. Drag a supported file format onto the executable to create a JSON file. Byte arrays are encoded as hex strings for SSBH types. JSON files are text files, so they can be viewed and edited in any text editor such as [VSCode](https://code.visualstudio.com/).
+A command-line tool for creating and editing SSBH binary data using JSON. The MeshEx and Adj formats are also supported. Drag a properly formatted JSON file onto the executable to create a binary file. Drag a supported file format onto the executable to create a JSON file. Byte arrays are encoded as hex strings for SSBH types. JSON files are text files, so they can be viewed and edited in any text editor such as [VSCode](https://code.visualstudio.com/).
 
 Sample output from a portion of an Hlpb file.
+
 ```json
 {
-  "data": {
-    "Hlpb": {
-      "major_version": 1,
-      "minor_version": 1,
-      "aim_entries": [],
-      "interpolation_entries": [
+  "Hlpb": {
+    "V11": {
+      "aim_constraints": [],
+      "orient_constraints": [
         {
           "name": "nuHelperBoneRotateInterp339",
-          "bone_name": "ArmL",
-          "root_bone_name": "ArmL",
-          "parent_bone_name": "HandL",
-          "driver_bone_name": "H_WristL",
+          "parent_bone_name1": "ArmL",
+          "parent_bone_name2": "ArmL",
+          "source_bone_name": "HandL",
+          "target_bone_name": "H_WristL",
 ```
 
 ### Usage
@@ -54,7 +53,7 @@ A prebuilt binary for Windows is available in [releases](https://github.com/ulti
 ### Editing a binary file
 - Output the JSON with `ssbh_lib_json.exe model.numshb mesh.json`  
 - Make changes to the JSON file such as adding elements to an array or changing field values
-- Save the changes to a new file with `ssbh_lib_json.exe mesh.json model.new.numshb`
+- Save the changes to a new file with `ssbh_lib_json.exe mesh.json model_new.numshb`
 
 ### Comparing two binary files
 ssbh_lib_json is used frequently during the development of ssbh_lib and ssbh_data for determining changes to a file without manually inspecting the file in a hex editor. 
@@ -69,11 +68,21 @@ Comparing the binary and JSON representations of two files gives clues as to how
 | :heavy_check_mark: | :heavy_check_mark: | The files are identical and contain the same data |
 
 ## ssbh_data_json
-A command line tool for creating and editing SSBH binary data using JSON. Drag a properly formatted JSON file onto the executable to create a binary file. Drag a supported file format onto the executable to create a JSON file.
+A command-line tool for creating and editing SSBH binary data using JSON. Drag a properly formatted JSON file onto the executable to create a binary file. Drag a supported file format onto the executable to create a JSON file.
 
 Sample output from a portion of an Anim file.
+
 ```json
 "name": "CustomVector8",
+"scale_options": {
+  "inherit_scale": false,
+  "compensate_scale": false
+},
+"transform_flags": {
+  "override_translation": false,
+  "override_rotation": false,
+  "override_scale": false
+},
 "values": {
   "Vector4": [
     {
@@ -87,8 +96,7 @@ Sample output from a portion of an Anim file.
 ```
 
 ### Feature Comparison
- ssbh_data_json provides a simplified and more readable output compared to ssbh_lib_json. This means that 
- resaving a file with ssbh_data_json may result in a file that is not binary identical with the original since some data needs to be recalculated.
+ ssbh_data_json provides a simplified and more readable output compared to ssbh_lib_json. This means that resaving a file with ssbh_data_json may result in a file that is not binary identical with the original since some data needs to be recalculated.
 
 | feature | ssbh_lib_json | ssbh_data_json |
 | --- | --- | --- |
@@ -104,7 +112,7 @@ Sample output from a portion of an Anim file.
 ### Editing a binary file
 - Output the JSON with `ssbh_lib_json.exe model.numshb mesh.json`  
 - Make changes to the JSON file such as adding elements to an array or changing field values
-- Save the changes to a new file with `ssbh_lib_json.exe mesh.json model.new.numshb`
+- Save the changes to a new file with `ssbh_lib_json.exe mesh.json model_new.numshb`
 
 ## Building
 With Rust 1.60 or later installed, run `cargo build --release`.
@@ -114,4 +122,4 @@ With Rust 1.60 or later installed, run `cargo build --release`.
 - [geometry_tools](https://github.com/ScanMountGoat/geometry_tools) - vertex data and geometry bounding calculations  
 - [BinRead](https://crates.io/crates/binread) - binary parsing library and inspiration for porting the C# implementation to Rust  
 - [glam](https://crates.io/crates/glam) - efficient vector and matrix math using SIMD
-- *see the cargo.toml files for the remaining projects used*
+- *see the Cargo.toml files for the remaining projects used*

--- a/ssbh_data/src/meshex_data.rs
+++ b/ssbh_data/src/meshex_data.rs
@@ -11,7 +11,7 @@ use geometry_tools::bounding::{
 use itertools::Itertools;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use ssbh_lib::formats::mesh::BoundingSphere;
+pub use ssbh_lib::formats::mesh::BoundingSphere;
 use ssbh_lib::formats::meshex::AllData;
 use ssbh_lib::{formats::meshex::MeshEx, Ptr64, Vector3};
 
@@ -270,7 +270,7 @@ mod tests {
             }),
             mesh_object_groups: Ptr64::new(vec![
                 MeshObjectGroup {
-                    bounding_sphere: bounding_sphere: BoundingSphere {
+                    bounding_sphere: BoundingSphere {
                         center: Vector3::new(1.0, 1.0, 1.0),
                         radius: 1.0,
                     },
@@ -278,7 +278,7 @@ mod tests {
                     mesh_object_name: Ptr64::new("a".into()),
                 },
                 MeshObjectGroup {
-                    bounding_sphere: bounding_sphere: BoundingSphere {
+                    bounding_sphere: BoundingSphere {
                         center: Vector3::new(2.0, 2.0, 2.0),
                         radius: 2.0,
                     },

--- a/ssbh_lib/src/formats/mesh.rs
+++ b/ssbh_lib/src/formats/mesh.rs
@@ -122,7 +122,7 @@ pub struct BoundingInfo {
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[derive(BinRead, Debug, SsbhWrite, Clone, Copy, Default)]
+#[derive(BinRead, Debug, SsbhWrite, Clone, Copy, PartialEq, Default)]
 pub struct BoundingSphere {
     pub center: Vector3,
     pub radius: f32,

--- a/ssbh_lib/src/formats/meshex.rs
+++ b/ssbh_lib/src/formats/meshex.rs
@@ -1,6 +1,7 @@
 use binrw::io::SeekFrom;
 
-use crate::{CString, Ptr64, Vector3, Vector4};
+use crate::{CString, Ptr64, Vector3};
+use crate::mesh::BoundingSphere;
 use binrw::{binread, BinRead};
 use modular_bitfield::prelude::*;
 
@@ -26,7 +27,7 @@ pub struct MeshEntry {
 #[derive(BinRead, Debug, SsbhWrite)]
 #[ssbhwrite(alignment = 16)]
 pub struct AllData {
-    pub bounding_sphere: Vector4,
+    pub bounding_sphere: BoundingSphere,
     pub name: Ptr64<CString<16>>,
 }
 
@@ -35,8 +36,8 @@ pub struct AllData {
 #[derive(BinRead, Debug, SsbhWrite)]
 #[ssbhwrite(alignment = 16)]
 pub struct MeshObjectGroup {
-    // TODO: The combined bounding information for mesh objects with the same name?
-    pub bounding_sphere: Vector4,
+    /// The combined bounding sphere information for mesh objects with the same name.
+    pub bounding_sphere: BoundingSphere,
     /// The name of the [MeshObject](crate::formats::mesh::MeshObject) including the tag such as "Mario_FaceN_VIS_O_OBJShape".
     pub mesh_object_full_name: Ptr64<CString<4>>,
     /// The name of the [MeshObject](crate::formats::mesh::MeshObject) such as "Mario_FaceN".
@@ -53,8 +54,11 @@ pub struct EntryFlag {
     pub cast_shadow: bool,
     #[skip]
     __: bool,
+    // TODO: Disables reflection of stage model in Fountain of Dreams's water.
     pub unk3: bool,
+    // TODO: Only draws stage model in Fountain of Dreams's water reflection.
     pub unk4: bool,
+    // TODO: Used for "light_neck_VIS_O_OBJShape" and "light_neck_lowShape" with subindices 1 in fighter/jack/model/doyle/c00/
     pub unk5: bool,
     #[skip]
     __: B10,


### PR DESCRIPTION
The MeshEx implementation was updated in both ssbh_lib and ssbh_data to retype the `bounding_sphere` field from `Vector4` to `ssbh_lib::formats::mesh::BoundingSphere`. Some comments were updated in the related modules and some new comments were added to the `EntryFlags` struct to partially document the unknown flags.

Additionally, due to changes over time in the JSON representation of the supported file formats, the two JSON excerpts in the README were updated to reflect the current output.