### PR TITLE
Add NLST format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Click the links below to see the corresponding Rust source file with the file fo
 | [Mesh](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/mesh.rs) (`.numshb`) | 1.8, 1.9, 1.10 |
 | [Skel](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/skel.rs) (`.nusktb`) | 1.0 |
 | [Anim](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/anim.rs) (`.nuanmb`) | 1.2, 2.0, 2.1 |
+| [Nlst](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/nlst.rs) (`.nulstb`) | 1.0 |
 | [Nrpd](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/nrpd.rs) (`.nurpdb`) | 1.6 |
 | [Nufx](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/nufx.rs) (`.nufxlb`) | 1.0, 1.1 |
 | [Shdr](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/shdr.rs) (`.nushdb`) | 1.2 |

--- a/ssbh_lib/README.md
+++ b/ssbh_lib/README.md
@@ -9,6 +9,7 @@ ssbh_lib is a Rust library for reading and writing SSBH binary files. Each SSBH 
 | [Mesh](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/mesh.rs) (`.numshb`) | 1.8, 1.9, 1.10 |
 | [Skel](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/skel.rs) (`.nusktb`) | 1.0 |
 | [Anim](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/anim.rs) (`.nuanmb`) | 1.2, 2.0, 2.1 |
+| [Nlst](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/nlst.rs) (`.nulstb`) | 1.0 |
 | [Nrpd](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/nrpd.rs) (`.nurpdb`) | 1.6 |
 | [Nufx](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/nufx.rs) (`.nufxlb`) | 1.0, 1.1 |
 | [Shdr](https://github.com/ultimate-research/ssbh_lib/blob/master/ssbh_lib/src/formats/shdr.rs) (`.nushdb`) | 1.2 |

--- a/ssbh_lib/fuzz/Cargo.toml
+++ b/ssbh_lib/fuzz/Cargo.toml
@@ -100,3 +100,9 @@ name = "shdr"
 path = "fuzz_targets/shdr.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "nlst"
+path = "fuzz_targets/nlst.rs"
+test = false
+doc = false

--- a/ssbh_lib/fuzz/fuzz_targets/nlst.rs
+++ b/ssbh_lib/fuzz/fuzz_targets/nlst.rs
@@ -1,0 +1,6 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: ssbh_lib::formats::nlst::Nlst| {
+    ssbh_lib_fuzz::test_write_read_write(&ssbh_lib::Versioned { data });
+});

--- a/ssbh_lib/src/formats.rs
+++ b/ssbh_lib/src/formats.rs
@@ -8,6 +8,7 @@ pub mod matl;
 pub mod mesh;
 pub mod meshex;
 pub mod modl;
+pub mod nlst;
 pub mod nrpd;
 pub mod nufx;
 pub mod shdr;

--- a/ssbh_lib/src/formats/nlst.rs
+++ b/ssbh_lib/src/formats/nlst.rs
@@ -1,0 +1,25 @@
+//! The [Nlst] format stores a collection of file names to load into the game.
+//! These files typically use the ".nulstb" suffix like "main.nulstb".
+use crate::{SsbhArray, SsbhString, Version};
+use binrw::BinRead;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use ssbh_write::SsbhWrite;
+
+/// A container of file names. Compatible with file version 1.0.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Debug, BinRead, SsbhWrite, Clone, PartialEq)]
+#[br(import(major_version: u16, minor_version: u16))]
+pub enum Nlst {
+    #[br(pre_assert(major_version == 1 && minor_version == 0))]
+    V10 { file_names: SsbhArray<SsbhString> },
+}
+
+impl Version for Nlst {
+    fn major_minor_version(&self) -> (u16, u16) {
+        match self {
+            Nlst::V10 { .. } => (1, 0),
+        }
+    }
+}

--- a/ssbh_lib/src/lib.rs
+++ b/ssbh_lib/src/lib.rs
@@ -20,6 +20,7 @@ match ssbh_file.data {
     ssbh_lib::Ssbh::Mesh(data) => println!("{:?}", data),
     ssbh_lib::Ssbh::Skel(data) => println!("{:?}", data),
     ssbh_lib::Ssbh::Anim(data) => println!("{:?}", data),
+    ssbh_lib::Ssbh::Nlst(data) => println!("{:?}", data),
     ssbh_lib::Ssbh::Nrpd(data) => println!("{:?}", data),
     ssbh_lib::Ssbh::Nufx(data) => println!("{:?}", data),
     ssbh_lib::Ssbh::Shdr(data) => println!("{:?}", data),
@@ -141,6 +142,7 @@ pub mod prelude {
     pub use crate::formats::mesh::Mesh;
     pub use crate::formats::meshex::MeshEx;
     pub use crate::formats::modl::Modl;
+    pub use crate::formats::nlst::Nlst;
     pub use crate::formats::nrpd::Nrpd;
     pub use crate::formats::nufx::Nufx;
     pub use crate::formats::shdr::Shdr;
@@ -302,6 +304,7 @@ ssbh_read_write_impl!(prelude::Modl, Ssbh::Modl, b"LDOM");
 ssbh_read_write_impl!(prelude::Mesh, Ssbh::Mesh, b"HSEM");
 ssbh_read_write_impl!(prelude::Skel, Ssbh::Skel, b"LEKS");
 ssbh_read_write_impl!(prelude::Anim, Ssbh::Anim, b"MINA");
+ssbh_read_write_impl!(prelude::Nlst, Ssbh::Nlst, b"TSLN");
 ssbh_read_write_impl!(prelude::Nrpd, Ssbh::Nrpd, b"DPRN");
 ssbh_read_write_impl!(prelude::Nufx, Ssbh::Nufx, b"XFUN");
 ssbh_read_write_impl!(prelude::Shdr, Ssbh::Shdr, b"RDHS");
@@ -520,6 +523,9 @@ pub enum Ssbh {
 
     #[br(magic = b"MINA")]
     Anim(Versioned<anim::Anim>),
+
+    #[br(magic = b"TSLN")]
+    Nlst(Versioned<nlst::Nlst>),
 
     #[br(magic = b"DPRN")]
     Nrpd(Versioned<nrpd::Nrpd>),
@@ -769,6 +775,7 @@ pub(crate) fn write_ssbh_header_and_data<W: Write + Seek>(
         Ssbh::Hlpb(hlpb) => write_ssbh_file(writer, &hlpb.data, b"BPLH"),
         Ssbh::Mesh(mesh) => write_ssbh_file(writer, &mesh.data, b"HSEM"),
         Ssbh::Nrpd(nrpd) => write_ssbh_file(writer, &nrpd.data, b"DPRN"),
+        Ssbh::Nlst(nlst) => write_ssbh_file(writer, &nlst.data, b"TSLN"),
     }
 }
 

--- a/ssbh_lib_json/src/main.rs
+++ b/ssbh_lib_json/src/main.rs
@@ -66,6 +66,7 @@ fn read_json_write_data<P: AsRef<Path>>(input_path: P, output_path: Option<Strin
             Ssbh::Mesh(_) => "numshb",
             Ssbh::Skel(_) => "nusktb",
             Ssbh::Anim(_) => "nuanmb",
+            Ssbh::Nlst(_) => "nulstb",
             Ssbh::Nrpd(_) => "nurpdb",
             Ssbh::Nufx(_) => "nuflxb",
             Ssbh::Shdr(_) => "nushdb",


### PR DESCRIPTION
The NLST file format is part of the SSBH family and comes from *Taiko no Tatsujin: Rhythm Festival*. It is the most simple SSBH format to date, storing a single `SsbhArray` of type `SsbhString`. File samples can be provided upon request, but the test cases of reading and writing one to two file names in the array resulted in binary-identical file outputs.